### PR TITLE
Fix builder to use toLowerCamel for assignment parameter

### DIFF
--- a/internal/constructor/builder_constructor_generator.go
+++ b/internal/constructor/builder_constructor_generator.go
@@ -47,7 +47,7 @@ func (cg *BuilderGenerator) Generate(indentLevel int) g.Statement {
 			g.NewFuncSignature(strcase.ToCamel(field.FieldName)).
 				AddParameters(g.NewFuncParameter(toLowerCamel(field.FieldName), field.FieldType)).
 				AddReturnTypes("*"+builderType),
-			g.NewRawStatement(fmt.Sprintf("b.%s = %s", toLowerCamel(field.FieldName), strcase.ToLowerCamel(field.FieldName))),
+			g.NewRawStatement(fmt.Sprintf("b.%s = %s", toLowerCamel(field.FieldName), toLowerCamel(field.FieldName))),
 			g.NewReturnStatement("b"),
 		))
 


### PR DESCRIPTION
Fixed builder constructor generator to use `toLowerCamel()` for assignment parameter too.

The use of different case conversion function (`toLowerCamel()` and `strcase.ToLowerCamel()`) has caused a mismatch between function parameter and assignment parameter.

e.g.
```go
func (b *HDPathBuilder) HDIndex(hdindex uint64) *HDPathBuilder {
	b.hdindex = hDIndex
	return b
}
```
