### PR TITLE
fix: multiple types import

### DIFF
--- a/cmd/gonstructor/gonstructor.go
+++ b/cmd/gonstructor/gonstructor.go
@@ -84,7 +84,7 @@ func main() {
 		fileHeaderGenerated            = false
 		rootStmt                       = g.NewRoot()
 	)
-	for _, typeName := range typeNames {
+	for i, typeName := range typeNames {
 		fields, err := constructor.CollectConstructorFieldsFromAST(typeName, astFiles)
 		if err != nil {
 			log.Fatal(fmt.Errorf("[error] failed to collect fields from files: %w", err))
@@ -139,6 +139,9 @@ func main() {
 
 		if *withGetter {
 			rootStmt = rootStmt.AddStatements(internal.GenerateGetters(typeName, fields))
+		}
+		if i != len(typeNames)-1 {
+			rootStmt = rootStmt.AddStatements(g.NewNewline())
 		}
 	}
 

--- a/cmd/gonstructor/gonstructor.go
+++ b/cmd/gonstructor/gonstructor.go
@@ -79,9 +79,11 @@ func main() {
 		log.Fatal(fmt.Errorf("[error] failed to parse a file: %w", err))
 	}
 
-	alreadyOpenedWithTruncFilesSet := map[string]bool{}
-
-	fileHeaderGenerated := false
+	var (
+		alreadyOpenedWithTruncFilesSet = map[string]bool{}
+		fileHeaderGenerated            = false
+		rootStmt                       = g.NewRoot()
+	)
 	for _, typeName := range typeNames {
 		fields, err := constructor.CollectConstructorFieldsFromAST(typeName, astFiles)
 		if err != nil {
@@ -95,8 +97,6 @@ func main() {
 				log.Fatal(fmt.Errorf("[error] failed to collect the return types of the init func: %w", err))
 			}
 		}
-
-		rootStmt := g.NewRoot()
 
 		if !fileHeaderGenerated {
 			rootStmt = rootStmt.AddStatements(
@@ -140,40 +140,40 @@ func main() {
 		if *withGetter {
 			rootStmt = rootStmt.AddStatements(internal.GenerateGetters(typeName, fields))
 		}
+	}
 
-		code, err := rootStmt.Goimports().EnableSyntaxChecking().Generate(0)
-		if err != nil {
-			log.Fatal(fmt.Errorf("[error] failed to generate code: %w", err))
+	code, err := rootStmt.Goimports().EnableSyntaxChecking().Generate(0)
+	if err != nil {
+		log.Fatal(fmt.Errorf("[error] failed to generate code: %w", err))
+	}
+
+	err = func() error {
+		fileName := getFilenameToGenerate(typeNames[0], *output, args)
+
+		fileOpenFlag := os.O_APPEND | os.O_WRONLY | os.O_CREATE
+		if !alreadyOpenedWithTruncFilesSet[fileName] {
+			// truncate and make a blank file
+			fileOpenFlag = os.O_TRUNC | os.O_WRONLY | os.O_CREATE
 		}
 
-		err = func() error {
-			fileName := getFilenameToGenerate(typeName, *output, args)
-
-			fileOpenFlag := os.O_APPEND | os.O_WRONLY | os.O_CREATE
-			if !alreadyOpenedWithTruncFilesSet[fileName] {
-				// truncate and make a blank file
-				fileOpenFlag = os.O_TRUNC | os.O_WRONLY | os.O_CREATE
-			}
-
-			f, err := os.OpenFile(fileName, fileOpenFlag, 0644)
-			if err != nil {
-				return fmt.Errorf("[error] failed open a file to output the generated code: %w", err)
-			}
-
-			defer f.Close()
-
-			alreadyOpenedWithTruncFilesSet[fileName] = true
-
-			_, err = f.WriteString(code)
-			if err != nil {
-				return fmt.Errorf("[error] failed output generated code to a file: %w", err)
-			}
-
-			return nil
-		}()
+		f, err := os.OpenFile(fileName, fileOpenFlag, 0644)
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("[error] failed open a file to output the generated code: %w", err)
 		}
+
+		defer f.Close()
+
+		alreadyOpenedWithTruncFilesSet[fileName] = true
+
+		_, err = f.WriteString(code)
+		if err != nil {
+			return fmt.Errorf("[error] failed output generated code to a file: %w", err)
+		}
+
+		return nil
+	}()
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Fixed a behavior which writes multiple imports when specifying multiple typeNames.

## before
```go
// Code generated by gonstructor -constructorTypes=allArgs -output model_gen.go --type Hoge --type Foo; DO NOT EDIT.

package model

import hoge "hoge"

func NewHoge(...) *Hoge {
	return &Hoge{...}
}
import foo "foo"

func NewFoo(...) *Foo {
	return &Foo{...}
}
```

## after
```go
// Code generated by gonstructor -constructorTypes=allArgs -output model_gen.go --type Hoge --type Foo; DO NOT EDIT.

package model

import (
	hoge "hoge"
	foo "foo"
)

func NewHoge(...) *Hoge {
	return &Hoge{...}
}

func NewFoo(...) *Foo {
	return &Foo{...}
}
```