### PR TITLE
feat: Option to return value instead of pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,27 @@ func NewStruct(foo string) (*Struct, error) {
 
 As you can see, the generated constructor `NewStruct()` returns the constructed value and an error that comes from `validate()` function.
 
+## How to return a value instead of a pointer
+
+`-returnValue` option supports that.
+
+For example,
+
+```go
+//go:generate gonstructor --type=Struct --constructorTypes=allArgs --returnValue
+type Struct struct {
+	foo string
+}
+```
+
+then it generates the following Go code:
+
+```go
+func NewStruct(foo string) Struct {
+	return Struct{foo: foo}
+}
+```
+
 ## How to build binaries
 
 Binaries are built and uploaded by [goreleaser](https://goreleaser.com/). Please refer to the configuration file: [.goreleaser.yml](./.goreleaser.yml)

--- a/cmd/gonstructor/gonstructor.go
+++ b/cmd/gonstructor/gonstructor.go
@@ -39,6 +39,7 @@ func main() {
 	withGetter := flag.Bool("withGetter", false, "[optional] generate a constructor along with getter functions for each field")
 	initFunc := flag.String("init", "", "[optional] name of function to call on object after creating it")
 	propagateInitFuncReturns := flag.Bool("propagateInitFuncReturns", false, `[optional] If this option is specified, the generated constructor propagates the return values that come from the init function specified by the "-init" option, e.g. when the init function returns an "error" value, the generated constructor returns (*YourStructType, error). Known issue: If this option is used with the multiple --type options, probably it won't be the expected result.`)
+	returnValue := flag.Bool("returnValue", false, "[optional] return value instead of pointer")
 
 	flag.Parse()
 
@@ -116,6 +117,7 @@ func main() {
 					InitFunc:                 *initFunc,
 					InitFuncReturnTypes:      initFuncReturnTypes,
 					PropagateInitFuncReturns: *propagateInitFuncReturns,
+					ReturnValue:              *returnValue,
 				}
 
 			case builderConstructorType:
@@ -125,6 +127,7 @@ func main() {
 					InitFunc:                 *initFunc,
 					InitFuncReturnTypes:      initFuncReturnTypes,
 					PropagateInitFuncReturns: *propagateInitFuncReturns,
+					ReturnValue:              *returnValue,
 				}
 
 			default:

--- a/internal/constructor/all_args_constructor_generator.go
+++ b/internal/constructor/all_args_constructor_generator.go
@@ -16,6 +16,7 @@ type AllArgsConstructorGenerator struct {
 	InitFunc                 string
 	InitFuncReturnTypes      []string
 	PropagateInitFuncReturns bool
+	ReturnValue              bool
 }
 
 // Generate generates a constructor statement with all of arguments.
@@ -36,14 +37,16 @@ func (cg *AllArgsConstructorGenerator) Generate(indentLevel int) g.Statement {
 		)
 	}
 
-	funcSignature = funcSignature.AddReturnTypes("*" + cg.TypeName).AddReturnTypes(func() []string {
-		if len(cg.InitFuncReturnTypes) <= 0 {
-			return []string{}
-		}
-		return cg.InitFuncReturnTypes
-	}()...)
+	funcSignature = funcSignature.
+		AddReturnTypes(withPrefix(cg.TypeName, "*", !cg.ReturnValue)).
+		AddReturnTypes(func() []string {
+			if len(cg.InitFuncReturnTypes) <= 0 {
+				return []string{}
+			}
+			return cg.InitFuncReturnTypes
+		}()...)
 
-	retStructure := generateStructure(cg.TypeName, retStructureKeyValues, indentLevel+1)
+	retStructure := generateStructure(cg.TypeName, retStructureKeyValues, indentLevel+1, cg.ReturnValue)
 
 	var stmts []g.Statement
 

--- a/internal/constructor/builder_constructor_generator.go
+++ b/internal/constructor/builder_constructor_generator.go
@@ -15,6 +15,7 @@ type BuilderGenerator struct {
 	InitFunc                 string
 	InitFuncReturnTypes      []string
 	PropagateInitFuncReturns bool
+	ReturnValue              bool
 }
 
 // Generate generates a builder statement.
@@ -54,7 +55,7 @@ func (cg *BuilderGenerator) Generate(indentLevel int) g.Statement {
 		retStructureKeyValues = append(retStructureKeyValues, fmt.Sprintf("%s: b.%s", field.FieldName, toLowerCamel(field.FieldName)))
 	}
 
-	buildResult := generateStructure(cg.TypeName, retStructureKeyValues, indentLevel+1)
+	buildResult := generateStructure(cg.TypeName, retStructureKeyValues, indentLevel+1, cg.ReturnValue)
 
 	var buildStmts []g.Statement
 	if cg.InitFunc != "" {
@@ -85,7 +86,7 @@ func (cg *BuilderGenerator) Generate(indentLevel int) g.Statement {
 
 	buildFunc := g.NewFunc(
 		g.NewFuncReceiver("b", "*"+builderType),
-		g.NewFuncSignature("Build").AddReturnTypes("*"+cg.TypeName).AddReturnTypes(func() []string {
+		g.NewFuncSignature("Build").AddReturnTypes(withPrefix(cg.TypeName, "*", !cg.ReturnValue)).AddReturnTypes(func() []string {
 			if len(cg.InitFuncReturnTypes) <= 0 {
 				return []string{}
 			}

--- a/internal/constructor/struct.go
+++ b/internal/constructor/struct.go
@@ -7,15 +7,16 @@ import (
 	g "github.com/moznion/gowrtr/generator"
 )
 
-func generateStructure(typeName string, keyValues []string, indentLevel int) string {
+func generateStructure(typeName string, keyValues []string, indentLevel int, returnValue bool) string {
 	indent := g.BuildIndent(indentLevel)
 	nextIndent := g.BuildIndent(indentLevel + 1)
 
-	return fmt.Sprintf(
-		"&%s{\n%s%s,\n%s}",
+	structure := fmt.Sprintf(
+		"%s{\n%s%s,\n%s}",
 		typeName,
 		nextIndent,
 		strings.Join(keyValues, ",\n"+nextIndent),
 		indent,
 	)
+	return withPrefix(structure, "&", !returnValue)
 }

--- a/internal/constructor/utils.go
+++ b/internal/constructor/utils.go
@@ -1,0 +1,12 @@
+package constructor
+
+import "fmt"
+
+// optionally returns the given string with the prefix applied
+// if the use prefix boolean is true
+func withPrefix(s, prefix string, usePrefix bool) string {
+	if !usePrefix {
+		prefix = ""
+	}
+	return fmt.Sprintf("%s%s", prefix, s)
+}

--- a/internal/constructor/utils_test.go
+++ b/internal/constructor/utils_test.go
@@ -1,0 +1,19 @@
+package constructor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithPrefix(t *testing.T) {
+	t.Run("apply prefix", func(t *testing.T) {
+		got := withPrefix("Struct", "*", true)
+		assert.Equal(t, "*Struct", got)
+	})
+
+	t.Run("ignore prefix", func(t *testing.T) {
+		got := withPrefix("Struct", "*", false)
+		assert.Equal(t, "Struct", got)
+	})
+}

--- a/internal/test/structure.go
+++ b/internal/test/structure.go
@@ -42,3 +42,8 @@ type StructureWithPointerEmbedding struct {
 	*Embedded
 	foo string
 }
+
+//go:generate sh -c "$(cd ./\"$(git rev-parse --show-cdup)\" || exit; pwd)/dist/gonstructor_test --type=StructureValue --constructorTypes=allArgs,builder --withGetter --returnValue"
+type StructureValue struct {
+	foo string
+}

--- a/internal/test/structure_test.go
+++ b/internal/test/structure_test.go
@@ -130,3 +130,13 @@ func TestStructureWithPointerEmbeddingBuilder(t *testing.T) {
 	assert.EqualValues(t, "bar", got.Bar)
 	assert.EqualValues(t, "bar", got.Embedded.Bar)
 }
+
+func TestStructureWithReturnValueBuilder(t *testing.T) {
+	got := NewStructureValueBuilder().Foo("foo").Build()
+	assert.IsType(t, StructureValue{}, got)
+}
+
+func TestStructureWithReturnValueAllArgs(t *testing.T) {
+	got := NewStructureValue("foo")
+	assert.IsType(t, StructureValue{}, got)
+}


### PR DESCRIPTION
Add an option `returnValue` to return the built struct as a value instead of a pointer.
Default is false so maintains the current behaviour.

Closes #23 