### PR TITLE
Support go 1.24+

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.23.x, 1.24.x, 1.25.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Do test
       run: make check-ci
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run GoReleaser

--- a/cmd/gonstructor/gonstructor.go
+++ b/cmd/gonstructor/gonstructor.go
@@ -163,7 +163,9 @@ func main() {
 			return fmt.Errorf("[error] failed open a file to output the generated code: %w", err)
 		}
 
-		defer f.Close()
+		defer func() {
+			_ = f.Close()
+		}()
 
 		alreadyOpenedWithTruncFilesSet[fileName] = true
 

--- a/go.mod
+++ b/go.mod
@@ -2,20 +2,20 @@ module github.com/moznion/gonstructor
 
 go 1.22
 
-toolchain go1.22.2
+toolchain go1.25.1
 
 require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/moznion/gowrtr v1.6.0
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/tools v0.22.0
+	golang.org/x/tools v0.37.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.18.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/mod v0.28.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moznion/gonstructor
 
-go 1.22
+go 1.24.0
 
 toolchain go1.25.1
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/moznion/gowrtr v1.6.0 h1:LKF1Alq3PbN8ePANPzQu9/kLEupaLfqviq28ETt1Za4=
@@ -14,12 +16,12 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
-golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
-golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
+golang.org/x/mod v0.28.0 h1:gQBtGhjxykdjY9YhZpSlZIsbnaE2+PgjfLWUQTnoZ1U=
+golang.org/x/mod v0.28.0/go.mod h1:yfB/L0NOf/kmEbXjzCPOx1iK1fRutOydrCMsqRhEBxI=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
+golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/test/structure_test.go
+++ b/internal/test/structure_test.go
@@ -91,7 +91,7 @@ func TestStructureWithEmbeddingAllArgsConstructor(t *testing.T) {
 
 	assert.EqualValues(t, "foo", got.foo)
 	assert.EqualValues(t, "bar", got.Bar)
-	assert.EqualValues(t, "bar", got.Embedded.Bar)
+	assert.EqualValues(t, "bar", got.Embedded.Bar) // nolint:staticcheck // for inspection
 
 	// test for getters
 	assert.EqualValues(t, "foo", got.GetFoo())
@@ -105,7 +105,7 @@ func TestStructureWithEmbeddingBuilder(t *testing.T) {
 
 	assert.EqualValues(t, "foo", got.foo)
 	assert.EqualValues(t, "bar", got.Bar)
-	assert.EqualValues(t, "bar", got.Embedded.Bar)
+	assert.EqualValues(t, "bar", got.Embedded.Bar) // nolint:staticcheck // for inspection
 }
 
 func TestStructureWithPointerEmbeddingAllArgsConstructor(t *testing.T) {
@@ -114,7 +114,7 @@ func TestStructureWithPointerEmbeddingAllArgsConstructor(t *testing.T) {
 
 	assert.EqualValues(t, "foo", got.foo)
 	assert.EqualValues(t, "bar", got.Bar)
-	assert.EqualValues(t, "bar", got.Embedded.Bar)
+	assert.EqualValues(t, "bar", got.Embedded.Bar) // nolint:staticcheck // for inspection
 
 	// test for getters
 	assert.EqualValues(t, "foo", got.GetFoo())
@@ -128,5 +128,5 @@ func TestStructureWithPointerEmbeddingBuilder(t *testing.T) {
 
 	assert.EqualValues(t, "foo", got.foo)
 	assert.EqualValues(t, "bar", got.Bar)
-	assert.EqualValues(t, "bar", got.Embedded.Bar)
+	assert.EqualValues(t, "bar", got.Embedded.Bar) // nolint:staticcheck // for inspection
 }


### PR DESCRIPTION
Fix https://github.com/moznion/gonstructor/issues/32

This pull request adds support for Go 1.24+ and drops support for Go 1.23 and earlier.